### PR TITLE
Add a case ruby stream to switch from ruby:2.6 to ruby:2.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,17 @@ env:
 
 matrix:
   include:
-    - name: ruby
-      env:
+    - env:
         - MODULE_NAME=ruby
         - CUR_STREAM=2.5
         - NEW_STREAM=2.6
       <<: *test_in_container
-    - name: nodejs
-      env:
+    - env:
+        - MODULE_NAME=ruby
+        - CUR_STREAM=2.6
+        - NEW_STREAM=2.5
+      <<: *test_in_container
+    - env:
         - MODULE_NAME=nodejs
         - CUR_STREAM=10
         - NEW_STREAM=12

--- a/script/ruby/install-deps-root.sh
+++ b/script/ruby/install-deps-root.sh
@@ -1,9 +1,14 @@
 #!/bin/bash -ex
 
-# Install dependencies for the installed gem packages.
+# Install RPM package dependencies for the installed gem packages.
 yum -y install \
   gcc \
   make \
   ruby-devel \
   rubygem-rdoc \
   redhat-rpm-config
+
+# Install RPM packages that can depend on one of current or new stream.
+yum -y install ruby-hivex ruby-libguestfs || true
+
+exit 0


### PR DESCRIPTION
Install ruby-hivex and ruby-libguestfs depending on only 2.6,
but not on 2.5 on Fedora 30, to test removed dependencies
by "yum --allowerasing distro-sync".