### PR TITLE
Use perl:5.28 instead of perl:5.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       <<: *test_in_container
     - env:
         - MODULE_NAME=perl
-        - CUR_STREAM=5.26
+        - CUR_STREAM=5.28
         - NEW_STREAM=5.30
         # Need to set a profile as the module does not have a default profile.
         - MODULE_PROFILE=default
@@ -52,7 +52,7 @@ matrix:
     - env:
         - MODULE_NAME=perl
         - CUR_STREAM=5.30
-        - NEW_STREAM=5.26
+        - NEW_STREAM=5.28
         - MODULE_PROFILE=default
       <<: *test_in_container
     - name: nginx


### PR DESCRIPTION
perl:5.26 is in current Fedoras only by an accident (wrong end-of-life
date) and we are even unable to rebuild it because the dist-git
branched are locked. perl:5.26 will be removed in December 2019.

This patch uses perl:5.28 instead that is supported.