### PR TITLE
List content of user gem direcotry.

### DIFF
--- a/script/ruby/install-deps-user.sh
+++ b/script/ruby/install-deps-user.sh
@@ -9,4 +9,4 @@ gem install byebug -v 11.0.1 --user-install
 gem install gem2rpm -v 1.0.1 --user-install
 gem install nio4r -v 2.5.1 --user-install
 gem list byebug gem2rpm nio4r
-ls ~/.gem/ruby/gems/
+find ~/.gem/


### PR DESCRIPTION
This helps to understand that RubyGems cannot find the `gem.build_complete` file, which is placed in versioned directory. Therefore RubyGems believes the binary extension was not built. It actually does not try to load the actual `.so` file, which would fail with different message.