### PR TITLE
Update ruby cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,24 @@ env:
 matrix:
   include:
     - env:
+        - BASE_IMAGE=fedora:31
         - MODULE_NAME=ruby
         - CUR_STREAM=2.5
         - NEW_STREAM=2.6
       <<: *test_in_container
     - env:
+        - BASE_IMAGE=fedora:31
         - MODULE_NAME=ruby
         - CUR_STREAM=2.6
         - NEW_STREAM=2.5
+      <<: *test_in_container
+    - env:
+        - MODULE_NAME=ruby
+        - CUR_STREAM=2.5
+        - NEW_STREAM=2.6
+        # Need to set a profile as the module does not have a default profile.
+        # https://pagure.io/releng/fedora-module-defaults/pull-request/163
+        - MODULE_PROFILE=default
       <<: *test_in_container
     # Only 1 stream is available on RHEL 8.0.
     - env:


### PR DESCRIPTION
I noticed current ruby module cases on f30 do not install the RPMs by "dnf module install ruby:2.5".
https://travis-ci.org/junaruga/switch-module-stream/jobs/587097018#L254

Because there is no default profile on f30 right now. I sent PR for that now here.
https://pagure.io/releng/fedora-module-defaults/pull-request/163

I also opened the ticket to change the behavior of "dnf module install $name:$profile" to return error code if the default profile is not set.
https://pagure.io/modularity/issue/154

* Add ruby module cases on f31.
* Update ruby module case on f30 adding the profile.
  As the ruby module on f30 does not have the default profile right now.
  