### PR TITLE
Add php case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,13 @@ matrix:
         - NEW_STREAM=5.28
         - MODULE_PROFILE=default
       <<: *test_in_container
+    - env:
+        # php module does not exist on Fedora.
+        - BASE_IMAGE=registry.access.redhat.com/ubi8:8.0
+        - MODULE_NAME=php
+        - CUR_STREAM=7.2
+        - NEW_STREAM=7.2
+      <<: *test_in_container
     - name: nginx
       env:
         - BASE_IMAGE=fedora:31

--- a/script/php/install-deps-root.sh
+++ b/script/php/install-deps-root.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+# Run common script.
+script/install-deps-root.sh
+
+# Install RPM package dependencies.
+yum -y install php-pear
+
+exit 0

--- a/script/php/test.sh
+++ b/script/php/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+php -v
+pear version


### PR DESCRIPTION
Add RHEL 8.0 case as the php module does not exist on Fedora.