### PR TITLE
Add NodeJS case

### DIFF
--- a/script/nodejs/install-deps-root.sh
+++ b/script/nodejs/install-deps-root.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+. script/install-deps-root.sh
+
+# Install node package manager and nodegit build dependencies
+yum -y install npm node-gyp python krb5-devel
+
+node --version; npm --version

--- a/script/nodejs/install-deps-user.sh
+++ b/script/nodejs/install-deps-user.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+node --version; npm --version
+# Install npm package with C extension as local package dependency
+mkdir nodejs-module-stream-switch-test-package && cd $_
+npm init --yes  # auto-fills package metadata
+npm install nodegit --build-from-source
+npm list        # lists all locally installed packages

--- a/script/nodejs/test.sh
+++ b/script/nodejs/test.sh
@@ -1,4 +1,10 @@
 #!/bin/bash -ex
 
-node -v
-npm -v
+node -v; npm -v
+
+cd nodejs-module-stream-switch-test-package && npm list
+
+# Trigger linking issue, then rebuild and test that works
+node -e 'require("nodegit");' || :
+npm rebuild --build-from-source
+node -e 'require("nodegit");'


### PR DESCRIPTION
Initial attempt at nodejs module switching.

These scripts install `nodegit` package dependencies, create a testing package and install `nodegit` from source as that package dependency.

From my local testing, unfortunately the only way to trigger a module-switching issue is to actually use the C dependency – `npm` itself will not complain about it being compiled against different stream.

Fixing the installation can be done by issuing `npm rebuild` in the package directory.

@junaruga, please let me know if these scripts are enough, or if you need them to do anything else.